### PR TITLE
Added finishedAt field + anticipate token expiration

### DIFF
--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -1,6 +1,9 @@
 name: build/test
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '30 5 * * *'
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## latest
+## v0.2.2-alpha
+* Added `FinishedAt` field to `TransactionAsyncResponse`.
+
+## v0.2.1-alpha
 * Fixed `executeAsync` inputs issue.
 
 ## v0.2.0-alpha

--- a/RelationalAI.Test/DatabaseTest.cs
+++ b/RelationalAI.Test/DatabaseTest.cs
@@ -17,8 +17,8 @@ namespace RelationalAI.Test
             Client client = CreateClient();
             client.CreateEngineWait(EngineName, size: EngineSize.XS);
 
-            var rsp = client.DeleteTransaction(Dbname);
-            Assert.Equal("Not Found", (JsonConvert.DeserializeObject(rsp) as JObject).GetValue("status").ToString());
+            var rsp = client.DeleteDatabase(Dbname);
+            Assert.Equal("Not Found", rsp.Message);
 
             var createRsp = client.CreateDatabase(Dbname, EngineName, overwrite: false);
             Assert.Equal(Dbname, createRsp.Name);

--- a/RelationalAI.Test/DatabaseTest.cs
+++ b/RelationalAI.Test/DatabaseTest.cs
@@ -17,8 +17,7 @@ namespace RelationalAI.Test
             Client client = CreateClient();
             client.CreateEngineWait(EngineName, size: EngineSize.XS);
 
-            var rsp = client.DeleteDatabase(Dbname);
-            Assert.Equal("Not Found", rsp.Message);
+            Assert.Throws<SystemException>( () => client.DeleteDatabase(Dbname) );
 
             var createRsp = client.CreateDatabase(Dbname, EngineName, overwrite: false);
             Assert.Equal(Dbname, createRsp.Name);

--- a/RelationalAI/Credentials/AccessToken.cs
+++ b/RelationalAI/Credentials/AccessToken.cs
@@ -38,7 +38,7 @@ namespace RelationalAI.Credentials
 
         public bool IsExpired
         {
-            get => (DateTime.Now - _createdOn).TotalSeconds >= ExpiresIn; 
+            get => (DateTime.Now - _createdOn).TotalSeconds >= ExpiresIn - 5; // Anticipate access token expiration by 5 seconds
         }
         public string Token 
         {

--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.2.1-alpha</Version>
+    <Version>0.2.2-alpha</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>RAI</PackageId>
     <Authors>RelationalAI</Authors>

--- a/RelationalAI/TransactionAsyncResponse.cs
+++ b/RelationalAI/TransactionAsyncResponse.cs
@@ -27,7 +27,10 @@ namespace RelationalAI
         public string CreatedBy { get; set; }
 
         [JsonProperty("created_on", Required = Required.Always)]
-        public string CreatedOn { get; set; }
+        public long CreatedOn { get; set; }
+
+        [JsonProperty("finished_at", Required = Required.Default)]
+        public long FinishedAt { get; set; }
 
         [JsonProperty("database_name", Required = Required.Always)]
         public string DatabaseName { get; set; }
@@ -46,7 +49,8 @@ namespace RelationalAI
             string state,
             string accountName,
             string createdBy,
-            string createdOn,
+            long createdOn,
+            long finishedAt,
             string databaseName,
             bool readOnly,
             string query,
@@ -56,6 +60,7 @@ namespace RelationalAI
             this.AccountName = accountName;
             this.CreatedBy = createdBy;
             this.CreatedOn = createdOn;
+            this.FinishedAt = finishedAt;
             this.DatabaseName = databaseName;
             this.ReadOnly = readOnly;
             this.Query = query;


### PR DESCRIPTION
This PR adds finishedAt transaction async field and anticipate the access token expiration.
Closes: https://github.com/RelationalAI/rai-sdk-issues/issues/51