### PR TITLE
Polly retry policies for waiting for async operation result

### DIFF
--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 namespace RelationalAI
 {
     using System;

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -156,7 +156,7 @@ namespace RelationalAI
             var resp = DeleteEngine(engine);
             resp.Status.State = Policy
                 .HandleResult<Engine>(e => !IsTerminalState(e.State, "DELETED"))
-                .Retry5Min()
+                .Retry15Min()
                 .Execute(() => GetEngine(engine)).State;
             return resp;
         }

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System.Net.Http;
 using Polly;
 using RelationalAI.Utils;
 
@@ -109,7 +108,7 @@ namespace RelationalAI
             var resp = Policy
                     .HandleResult<Engine>(e => !IsTerminalState(e.State, "PROVISIONED"))
                     .WaitAndRetryForever(_ => TimeSpan.FromSeconds(2))
-                    .Wrap(CommonPolicies.RequestErrorResilience)
+                    .AddRequestErrorResilience()
                     .Execute(() => GetEngine(engine));
             return resp;
         }
@@ -154,7 +153,7 @@ namespace RelationalAI
             resp.Status.State = Policy
                 .HandleResult<Engine>(e => !IsTerminalState(e.State, "DELETED"))
                 .WaitAndRetryForever(_ => TimeSpan.FromSeconds(2))
-                .Wrap(CommonPolicies.RequestErrorResilience)
+                .AddRequestErrorResilience()
                 .Execute(() => GetEngine(engine)).State;
             return resp;
         }
@@ -460,7 +459,7 @@ namespace RelationalAI
                 .HandleResult<TransactionAsyncSingleResponse>(r =>
                     !(r.Transaction.State.Equals("COMPLETED") || r.Transaction.State.Equals("ABORTED")))
                 .WaitAndRetryForever(_ => TimeSpan.FromSeconds(2))
-                .Wrap(CommonPolicies.RequestErrorResilience)
+                .AddRequestErrorResilience()
                 .Execute(() => GetTransaction(id)).Transaction;
 
             var results = GetTransactionResults(id);

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-using Polly;
-using RelationalAI.Utils;
 
 namespace RelationalAI
 {
     using System;
-    using System.Text;
     using System.Collections.Generic;
+    using System.Text;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
+    using Polly;
     using RelationalAI.Credentials;
+    using RelationalAI.Utils;
 
     public class Client
     {

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -108,6 +108,13 @@ namespace RelationalAI
                     .WaitAndRetryForever(_ => TimeSpan.FromSeconds(2))
                     .AddRequestErrorResilience()
                     .Execute(() => GetEngine(engine));
+
+            if (resp.State != "PROVISIONED")
+            {
+                // TODO: replace with a better error during introducing the exceptions hierarchy
+                throw new SystemException("Failed to provision engine");
+            }
+
             return resp;
         }
 

--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -64,9 +64,7 @@ namespace RelationalAI.Utils
         /// <returns>Resulting policy instance.</returns>
         public static Policy<T> Retry5Min<T>(this PolicyBuilder<T> policyBuilder)
         {
-            return policyBuilder
-                .AddBoundedRetryPolicy(15, 5 * 60)
-                .AddRequestErrorResilience();
+            return policyBuilder.AddBoundedRetryPolicy(15, 5 * 60);
         }
 
         /// <summary>
@@ -80,9 +78,7 @@ namespace RelationalAI.Utils
         /// <returns>Resulting policy instance.</returns>
         public static Policy<T> Retry30Min<T>(this PolicyBuilder<T> policyBuilder)
         {
-            return policyBuilder
-                .AddBoundedRetryPolicy(15, 30 * 60)
-                .AddRequestErrorResilience();
+            return policyBuilder.AddBoundedRetryPolicy(15, 30 * 60);
         }
 
         /// <summary>

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using Polly;
 using Polly.Retry;
+using Polly.Wrap;
 
 namespace RelationalAI.Utils
 {
@@ -12,6 +13,11 @@ namespace RelationalAI.Utils
         static CommonPolicies()
         {
             RequestErrorResilience = GetRequestErrorResiliencePolicy();
+        }
+
+        public static PolicyWrap<T> AddRequestErrorResilience<T>(this ISyncPolicy<T> policy)
+        {
+            return policy.Wrap(RequestErrorResilience);
         }
 
         public static RetryPolicy GetRequestErrorResiliencePolicy()

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -30,11 +30,7 @@ namespace RelationalAI.Utils
             RequestErrorResilience = GetRequestErrorResiliencePolicy();
         }
 
-        /// <summary>
-        /// Gets a policy that retries 5 times with exponential back-off on HTTP request sending errors,
-        /// such as network connectivity issues, or 5xx status codes due to temporary server unavailability.
-        /// </summary>
-        public static Policy RequestErrorResilience { get; }
+        private static Policy RequestErrorResilience { get; }
 
         /// <summary>
         /// Creates a policy that can be used to produce synchronous API for async calls that may be taking a long
@@ -88,7 +84,7 @@ namespace RelationalAI.Utils
         /// <typeparam name="T">Type of result of an operation.</typeparam>
         /// <param name="policy">Initial policy instance.</param>
         /// <returns>Resulting policy instance.</returns>
-        public static Policy<T> AddRequestErrorResilience<T>(this ISyncPolicy<T> policy)
+        private static Policy<T> AddRequestErrorResilience<T>(this ISyncPolicy<T> policy)
         {
             return policy.Wrap(RequestErrorResilience);
         }

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -1,4 +1,19 @@
-﻿namespace RelationalAI.Utils
+﻿/*
+ * Copyright 2022 RelationalAI, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace RelationalAI.Utils
 {
     using System;
     using System.Net.Http;
@@ -6,33 +21,68 @@
     using Polly.Retry;
     using Polly.Wrap;
 
+    /// <summary>
+    /// Defines a number of commonly used policies to allow retrying operations based on various conditions.
+    /// </summary>
     public static class CommonPolicies
     {
-        public static RetryPolicy RequestErrorResilience { get; }
-
         static CommonPolicies()
         {
             RequestErrorResilience = GetRequestErrorResiliencePolicy();
         }
 
+        /// <summary>
+        /// Gets a policy that retries 5 times with exponential back-off on HTTP request sending errors,
+        /// such as network connectivity issues, or 5xx status codes due to temporary server unavailability.
+        /// </summary>
+        public static RetryPolicy RequestErrorResilience { get; }
+
+        /// <summary>
+        /// Adds a policy that retries 5 times with exponential back-off on HTTP request sending errors,
+        /// such as network connectivity issues, or 5xx status codes due to temporary server unavailability.
+        /// </summary>
+        /// <typeparam name="T">Type of result of an operation.</typeparam>
+        /// <param name="policy">Initial policy instance.</param>
+        /// <returns>Resulting policy instance.</returns>
         public static PolicyWrap<T> AddRequestErrorResilience<T>(this ISyncPolicy<T> policy)
         {
             return policy.Wrap(RequestErrorResilience);
         }
 
-        public static RetryPolicy GetRequestErrorResiliencePolicy()
+        /// <summary>
+        /// Retries a specified number of times, using the 2^n function to calculate the duration to wait between retries
+        /// based on the current retry attempt (exponential back-off).
+        /// </summary>
+        /// <typeparam name="T">Type of result of an operation.</typeparam>
+        /// <param name="policyBuilder">The policy builder.</param>
+        /// <param name="retryCount">The number of times to retry an operation.</param>
+        /// <returns>Resulting policy instance.</returns>
+        public static RetryPolicy<T> WaitExponentiallyAndRetry<T>(this PolicyBuilder<T> policyBuilder, int retryCount)
+        {
+            return policyBuilder.WaitAndRetry(retryCount, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+        }
+
+        private static RetryPolicy GetRequestErrorResiliencePolicy()
         {
             return Policy
+
                 // The request failed due to an underlying issue such as network connectivity, DNS
                 // failure, server certificate validation or timeout.
                 .Handle<HttpRequestException>()
 
-                // 5** status code response received, etc. and response deserialization failed
+                // Response deserialization failed due to unsuccessful response received (5xx status code, etc.)
                 // TODO: update after introducing exceptions hierarchy
                 .Or<SystemException>()
 
-                // Exponential backoff pattern
-                .WaitAndRetry(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+                // Retry 5 times, using 2^n function to calculate the duration to wait between retries
+                // based on the current retry attempt. In this case will wait for:
+                //  2 ^ 1 = 2 seconds then
+                //  2 ^ 2 = 4 seconds then
+                //  2 ^ 3 = 8 seconds then
+                //  2 ^ 4 = 16 seconds then
+                //  2 ^ 5 = 32 seconds (1 min in total)
+                // And rethrow the exception.
+                .WaitAndRetry(5, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
         }
     }
 }

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Net.Http;
+using Polly;
+using Polly.Retry;
+
+namespace RelationalAI.Utils
+{
+    public static class CommonPolicies
+    {
+        public static RetryPolicy RequestErrorResilience { get; }
+
+        static CommonPolicies()
+        {
+            RequestErrorResilience = GetRequestErrorResiliencePolicy();
+        }
+
+        public static RetryPolicy GetRequestErrorResiliencePolicy()
+        {
+            return Policy
+                // The request failed due to an underlying issue such as network connectivity, DNS
+                // failure, server certificate validation or timeout.
+                .Handle<HttpRequestException>()
+
+                // 5** status code response received, etc. and response deserialization failed
+                // TODO: update after introducing exceptions hierarchy
+                .Or<SystemException>()
+
+                // Exponential backoff pattern
+                .WaitAndRetry(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+        }
+    }
+}

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -22,7 +22,8 @@ namespace RelationalAI.Utils
     using Polly.Wrap;
 
     /// <summary>
-    /// Defines a number of commonly used policies to allow retrying operations based on various conditions.
+    /// Defines a number of commonly used policies and extension methods to use them
+    /// to allow retrying operations based on various conditions.
     /// </summary>
     public static class CommonPolicies
     {

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -54,7 +54,7 @@ namespace RelationalAI.Utils
         }
 
         /// <summary>
-        /// Creates a policy that can be used to produce synchronous API for async calls which may be taking less than 5 min
+        /// Creates a policy that can be used to produce synchronous API for async calls which may be taking less than 15 min
         /// to complete, otherwise throws TimeoutRejectedException.
         /// Uses exponential back-off starting with a 2 seconds delay up to 15 seconds and then retrying every 15 seconds.
         /// Retries on HTTP request sending errors.
@@ -62,9 +62,9 @@ namespace RelationalAI.Utils
         /// <typeparam name="T">Result type of an operation.</typeparam>
         /// <param name="policyBuilder">The policy builder.</param>
         /// <returns>Resulting policy instance.</returns>
-        public static Policy<T> Retry5Min<T>(this PolicyBuilder<T> policyBuilder)
+        public static Policy<T> Retry15Min<T>(this PolicyBuilder<T> policyBuilder)
         {
-            return policyBuilder.AddBoundedRetryPolicy(15, 5 * 60);
+            return policyBuilder.AddBoundedRetryPolicy(15, 15 * 60);
         }
 
         /// <summary>

--- a/RelationalAI/Utils/CommonPolicies.cs
+++ b/RelationalAI/Utils/CommonPolicies.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Net.Http;
-using Polly;
-using Polly.Retry;
-using Polly.Wrap;
-
-namespace RelationalAI.Utils
+﻿namespace RelationalAI.Utils
 {
+    using System;
+    using System.Net.Http;
+    using Polly;
+    using Polly.Retry;
+    using Polly.Wrap;
+
     public static class CommonPolicies
     {
         public static RetryPolicy RequestErrorResilience { get; }


### PR DESCRIPTION
* Use [Polly](https://github.com/App-vNext/Polly/wiki/Retry) library to retry requests instead of `while` loop with `Thread.Sleep()` when need to wait for some result / status. Limit engine provisioning time to 30 min and engine deletion to 15 min, exponentially backing off with 15s delay threshold.
* Create automatic exponential retries policy on `HttpRequestException` and `SystemException` due to unsuccessful response (5xx status code) and add it to *waiting for async operation result*.