### PR TITLE
Added a new function to create engine with a custom version

### DIFF
--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.8.0-alpha</Version>
+    <Version>0.9.0-alpha</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>RAI</PackageId>
     <Authors>RelationalAI</Authors>

--- a/RelationalAI/Services/Client.cs
+++ b/RelationalAI/Services/Client.cs
@@ -111,7 +111,10 @@ namespace RelationalAI.Services
             return Json<DeleteDatabaseResponse>.Deserialize(resp);
         }
 
-        public async Task<Engine> CreateEngineAsync(string engine, EngineSize size = EngineSize.XS)
+        public async Task<Engine> CreateEngineAsync(
+            string engine,
+            EngineSize size = EngineSize.XS,
+            Dictionary<string, string> customHeaders = null)
         {
             var data = new Dictionary<string, string>
             {
@@ -119,13 +122,16 @@ namespace RelationalAI.Services
                 { "name", engine },
                 { "size", size.ToString() }
             };
-            var resp = await _rest.PutAsync(MakeUrl(PathEngine), data) as string;
+            var resp = await _rest.PutAsync(MakeUrl(PathEngine), data, headers: customHeaders) as string;
             return Json<CreateEngineResponse>.Deserialize(resp).Engine;
         }
 
-        public async Task<Engine> CreateEngineWaitAsync(string engine, EngineSize size = EngineSize.XS)
+        public async Task<Engine> CreateEngineWaitAsync(
+            string engine,
+            EngineSize size = EngineSize.XS,
+            Dictionary<string, string> customHeaders = null)
         {
-            await CreateEngineAsync(engine, size);
+            await CreateEngineAsync(engine, size, customHeaders);
             var resp = await Policy
                     .HandleResult<Engine>(e => !e.State.IsTerminalState(EngineState.Provisioned))
                     .Retry30Min()


### PR DESCRIPTION
There is a requirement to include the EY-Tim integration tests in the raicode deployment workflow. For that we need to test against the currently built engine version. The compute service supports passing a custom engine version header in the create engine request.  Added a new function to create the engine with the provided version.