### PR TITLE
Use string instead of enum for engine states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.9.3-alpha
+* Removed `EngineState` enumeration:
+    - `ListEnginesAsync(state = "PROVISIONED")`
 ## v0.9.2-alpha
 * Removed `EngineSize` enumeration:
   - `CreateEngineAsync(engineName, size = "XS")`

--- a/RelationalAI.Examples/ListEngines.cs
+++ b/RelationalAI.Examples/ListEngines.cs
@@ -13,7 +13,7 @@ namespace RelationalAI.Examples
         public static Command GetCommand()
         {
             var cmd = new Command("ListEngines", "--state <State> --profile <Profile name>"){
-                new Option<EngineState>("--state"){
+                new Option<string>("--state"){
                     IsRequired = false,
                     Description = "To list engines in a paricular state. For example, DELETED"
                 },
@@ -24,11 +24,11 @@ namespace RelationalAI.Examples
                 }
             };
             cmd.Description = "Lists engines.";
-            cmd.Handler = CommandHandler.Create<EngineState?, string>(Run);
+            cmd.Handler = CommandHandler.Create<string, string>(Run);
             return cmd;
         }
 
-        private static async Task Run(EngineState? state = null, string profile = "default")
+        private static async Task Run(string state = null, string profile = "default")
         {
             var config = Config.Read("", profile);
             var context = new Client.Context(config);

--- a/RelationalAI.Test/EngineTest.cs
+++ b/RelationalAI.Test/EngineTest.cs
@@ -18,22 +18,19 @@ namespace RelationalAI.Test
 
             var createRsp = await client.CreateEngineWaitAsync(EngineName);
             Assert.Equal(createRsp.Name, EngineName);
-            Assert.Equal(EngineState.Provisioned, createRsp.State);
+            Assert.Equal("PROVISIONED", createRsp.State);
 
             var engine = await client.GetEngineAsync(EngineName);
             Assert.Equal(engine.Name, EngineName);
-            Assert.Equal(EngineState.Provisioned, engine.State);
+            Assert.Equal(EngineStates.Provisioned, engine.State);
 
             var engines = await client.ListEnginesAsync();
             engine = engines.Find(item => item.Name.Equals(EngineName));
             Assert.NotNull(engine);
 
-            engines = await client.ListEnginesAsync(EngineState.Provisioned);
+            engines = await client.ListEnginesAsync(EngineStates.Provisioned);
             engine = engines.Find(item => item.Name.Equals(EngineName));
             Assert.NotNull(engine);
-
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-                client.ListEnginesAsync((EngineState)1500));
 
             await Assert.ThrowsAsync<NotFoundException>(async () => await client.DeleteEngineWaitAsync(EngineName));
 
@@ -41,7 +38,7 @@ namespace RelationalAI.Test
 
             engines = await client.ListEnginesAsync();
             engine = engines.Find(item => item.Name.Equals(EngineName));
-            Assert.Equal(EngineState.Deleted, engine.State);
+            Assert.Equal(EngineStates.Deleted, engine.State);
         }
 
         public override async Task DisposeAsync()

--- a/RelationalAI.Test/EngineTest.cs
+++ b/RelationalAI.Test/EngineTest.cs
@@ -18,7 +18,7 @@ namespace RelationalAI.Test
 
             var createRsp = await client.CreateEngineWaitAsync(EngineName);
             Assert.Equal(createRsp.Name, EngineName);
-            Assert.Equal("PROVISIONED", createRsp.State);
+            Assert.Equal(EngineStates.Provisioned, createRsp.State);
 
             var engine = await client.GetEngineAsync(EngineName);
             Assert.Equal(engine.Name, EngineName);

--- a/RelationalAI/Models/Engine/DeleteEngineStatus.cs
+++ b/RelationalAI/Models/Engine/DeleteEngineStatus.cs
@@ -26,8 +26,7 @@ namespace RelationalAI.Models.Engine
         public string Name { get; set; }
 
         [JsonProperty("state", Required = Required.Always)]
-        [JsonConverter(typeof(StringEnumConverter), typeof(SnakeCaseNamingStrategy))]
-        public EngineState State { get; set; }
+        public string State { get; set; }
 
         [JsonProperty("message")]
         public string Message { get; set; }

--- a/RelationalAI/Models/Engine/Engine.cs
+++ b/RelationalAI/Models/Engine/Engine.cs
@@ -44,7 +44,6 @@ namespace RelationalAI.Models.Engine
         public string Size { get; set; }
 
         [JsonProperty("state")]
-        [JsonConverter(typeof(StringEnumConverter), typeof(SnakeCaseNamingStrategy))]
-        public EngineState State { get; set; }
+        public string State { get; set; }
     }
 }

--- a/RelationalAI/Models/Engine/EngineStates.cs
+++ b/RelationalAI/Models/Engine/EngineStates.cs
@@ -19,50 +19,15 @@ using System;
 namespace RelationalAI.Models.Engine
 {
     /// <summary>
-    /// Represents all engine lifetime states.
-    /// </summary>
-    public enum EngineState
-    {
-        Requested,
-        Provisioning,
-        Registering,
-        Provisioned,
-        ProvisionFailed,
-        DeleteRequested,
-        Stopping,
-        Deleting,
-        Deleted,
-        DeletionFailed
-    }
-
-    /// <summary>
-    /// Extension methods for EngineState enum such as conversion to string, terminal states identification.
+    /// Methods for EngineState determinations such as terminal states identification.
     /// </summary>
     public static class EngineStates
     {
-        /// <summary>
-        /// Converts <paramref name="state"/> to string value RAI REST API returns.
-        /// </summary>
-        /// <param name="state">Engine state.</param>
-        /// <returns>The string value.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Gets thrown when unsupported enum value is passed.</exception>
-        public static string Value(this EngineState state)
-        {
-            return state switch
-            {
-                EngineState.Requested => "REQUESTED",
-                EngineState.Provisioning => "PROVISIONING",
-                EngineState.Registering => "REGISTERING",
-                EngineState.Provisioned => "PROVISIONED",
-                EngineState.ProvisionFailed => "PROVISION_FAILED",
-                EngineState.DeleteRequested => "DELETE_REQUESTED",
-                EngineState.Stopping => "STOPPING",
-                EngineState.Deleting => "DELETING",
-                EngineState.Deleted => "DELETED",
-                EngineState.DeletionFailed => "DELETION_FAILED",
-                _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Engine state is not supported")
-            };
-        }
+        public static readonly string Deleted = "DELETED";
+        public static readonly string DeletionFailed = "DELETION_FAILED";
+        public static readonly string Provisioned = "PROVISIONED";
+        public static readonly string ProvisionFailed = "PROVISION_FAILED";
+        public static readonly string RequestFailed = "REQUEST_FAILED";
 
         /// <summary>
         /// Identifies if <paramref name="state"/> is the final state of engine,
@@ -70,11 +35,12 @@ namespace RelationalAI.Models.Engine
         /// </summary>
         /// <param name="state">The engine state to check.</param>
         /// <returns>If the state if final.</returns>
-        public static bool IsFinalState(this EngineState state)
+        public static bool IsFinalState(string state)
         {
-            return state == EngineState.ProvisionFailed ||
-                   state == EngineState.Deleted ||
-                   state == EngineState.DeletionFailed;
+            return state == ProvisionFailed ||
+                   state == Deleted ||
+                   state == DeletionFailed ||
+                   state == RequestFailed;
         }
 
         /// <summary>
@@ -84,9 +50,9 @@ namespace RelationalAI.Models.Engine
         /// <param name="currentState">The current state.</param>
         /// <param name="targetState">The target state.</param>
         /// <returns>If the current state is terminal.</returns>
-        public static bool IsTerminalState(this EngineState currentState, EngineState targetState)
+        public static bool IsTerminalState(string currentState, string targetState)
         {
-            return currentState == targetState || currentState.IsFinalState();
+            return currentState == targetState || IsFinalState(currentState);
         }
     }
 }

--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -31,9 +31,7 @@
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
-    <PackageReference Include="HttpMultipartParser" Version="5.1.0" />
     <PackageReference Include="Apache.Arrow" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Data.Analysis" Version="0.19.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.9.2-alpha</Version>
+    <Version>0.9.3-alpha</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>RAI</PackageId>
     <Authors>RelationalAI</Authors>


### PR DESCRIPTION
Fix for issue https://github.com/RelationalAI/rai-sdk-csharp/issues/33
Removed the EngineStates enum and started using string for engine states.