### PR TITLE
Expose http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## main
+* Exposed http client
+```
+var client = new Client(ctx);
+var httpClient = client.GetHttpClient();
+```
+
 ## v0.9.4-alpha
 * Refactored sdk code back into a single package.
 

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -380,7 +380,6 @@ namespace RelationalAI
             var models = new List<string>();
             var resp = await ExecuteAsync(database, engine, query);
 
-
             var result = resp.Results.Find(r => r.RelationId.Equals($"/:output/:{outName}/String"));
             if (result != null)
             {

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -49,6 +49,11 @@ namespace RelationalAI
             return _rest.HttpClient;
         }
 
+        public void SetHttpClient(HttpClient httpClient)
+        {
+            _rest.HttpClient = httpClient;
+        }
+
         public Task<Database> CreateDatabaseAsync(string database, string engine)
         {
             return CreateDatabaseAsync(database, engine, false);

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -41,6 +42,11 @@ namespace RelationalAI
         {
             _context = context;
             _rest = new Rest(context);
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return _rest.HttpClient;
         }
 
         public Task<Database> CreateDatabaseAsync(string database, string engine)

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -125,6 +125,29 @@ namespace RelationalAI
             return Json<CreateEngineResponse>.Deserialize(resp).Engine;
         }
 
+        // This function is no longer needed and will be deprecated soon
+        // please make sure to use the exposed http client to set custom headers
+        public async Task<Engine> CreateEngineWithVersionAsync(string engine, string version, string size = "XS")
+        {
+            Console.WriteLine(@"
+            This function will be deprecated in the next release
+            Please make sure to use the exposed http client to set custom headers
+            ");
+            var data = new Dictionary<string, string>
+            {
+                { "region", _context.Region },
+                { "name", engine },
+                { "size", size.ToString() }
+            };
+            var headers = new Dictionary<string, string>
+            {
+                { "x-rai-parameter-compute-version", version },
+            };
+
+            var resp = await _rest.PutAsync(MakeUrl(PathEngine), data, headers: headers) as string;
+            return Json<CreateEngineResponse>.Deserialize(resp).Engine;
+        }
+
         public async Task<Engine> CreateEngineWaitAsync(string engine, string size = "XS")
         {
             await CreateEngineAsync(engine, size);

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -125,14 +125,9 @@ namespace RelationalAI
             return Json<CreateEngineResponse>.Deserialize(resp).Engine;
         }
 
-        // This function is no longer needed and will be deprecated soon
-        // please make sure to use the exposed http client to set custom headers
+        [Obsolete("This method is deprecated, please use the exposed http client instead")]
         public async Task<Engine> CreateEngineWithVersionAsync(string engine, string version, string size = "XS")
         {
-            Console.WriteLine(@"
-            This function will be deprecated in the next release
-            Please make sure to use the exposed http client to set custom headers
-            ");
             var data = new Dictionary<string, string>
             {
                 { "region", _context.Region },

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -125,23 +125,6 @@ namespace RelationalAI
             return Json<CreateEngineResponse>.Deserialize(resp).Engine;
         }
 
-        public async Task<Engine> CreateEngineWithVersionAsync(string engine, string version, string size = "XS")
-        {
-            var data = new Dictionary<string, string>
-            {
-                { "region", _context.Region },
-                { "name", engine },
-                { "size", size.ToString() }
-            };
-            var headers = new Dictionary<string, string>
-            {
-                { "x-rai-parameter-compute-version", version },
-            };
-
-            var resp = await _rest.PutAsync(MakeUrl(PathEngine), data, headers: headers) as string;
-            return Json<CreateEngineResponse>.Deserialize(resp).Engine;
-        }
-
         public async Task<Engine> CreateEngineWaitAsync(string engine, string size = "XS")
         {
             await CreateEngineAsync(engine, size);

--- a/RelationalAI/Rest.cs
+++ b/RelationalAI/Rest.cs
@@ -38,13 +38,13 @@ namespace RelationalAI
 
         private readonly Context _context;
 
-        public HttpClient HttpClient { get; set; }
-
         public Rest(Context context)
         {
             _context = context;
             HttpClient = new HttpClient();
         }
+
+        public HttpClient HttpClient { get; set; }
 
         public static string EncodeQueryString(Dictionary<string, string> parameters)
         {

--- a/RelationalAI/Rest.cs
+++ b/RelationalAI/Rest.cs
@@ -38,7 +38,7 @@ namespace RelationalAI
 
         private readonly Context _context;
 
-        public HttpClient HttpClient { get; }
+        public HttpClient HttpClient { get; set; }
 
         public Rest(Context context)
         {

--- a/RelationalAI/Rest.cs
+++ b/RelationalAI/Rest.cs
@@ -38,9 +38,12 @@ namespace RelationalAI
 
         private readonly Context _context;
 
+        public HttpClient HttpClient { get; }
+
         public Rest(Context context)
         {
             _context = context;
+            HttpClient = new HttpClient();
         }
 
         public static string EncodeQueryString(Dictionary<string, string> parameters)
@@ -333,17 +336,11 @@ namespace RelationalAI
             Dictionary<string, string> headers = null,
             Dictionary<string, string> parameters = null)
         {
-            var uri = new Uri(url);
-            using var client = new HttpClient();
-
-            // Set the API url
-            client.BaseAddress = uri;
-
             // Create the POST request
-            var request = PrepareHttpRequest(method, client.BaseAddress, EncodeContent(data), headers, parameters);
+            var request = PrepareHttpRequest(method, new Uri(url), EncodeContent(data), headers, parameters);
 
             // Get the result back or throws an exception.
-            var response = await client.SendAsync(request);
+            var response = await HttpClient.SendAsync(request);
             await EnsureSuccessResponseAsync(response);
             var content = await response.Content.ReadAsByteArrayAsync();
             var contentType = response.Content.Headers.ContentType.MediaType;


### PR DESCRIPTION
This PR exposes the sdk http client, this is useful for changing the http client properties
Adds the ability to set http custom headers
```
...
var client = new Client(context);
var httpClient = client.GetHttpClient();
httpClient.DefaultRequestHeaders.Add("h1", "v1");

// set a new http client
// default properties of http client cannot be updated 
// thus a new http client might be useful
var httpClient = new HttpClient();

// change the http client properties
...
client.SetHttpClient(httpClient);
```