### PR TITLE
Disable the User Tests until Auth0 API rate limiting issues are not fixed

### DIFF
--- a/RelationalAI.Test/UserTest.cs
+++ b/RelationalAI.Test/UserTest.cs
@@ -11,7 +11,7 @@ namespace RelationalAI.Test
         public static string Uuid = Guid.NewGuid().ToString();
         public static string UserEmail = $"csharp-sdk-{Uuid}@example.com";
 
-        [Fact (Skip = "User tests are hitting Auth0 API rate limits")]
+        [Fact(Skip="User tests are hitting Auth0 API rate limits")]
         public async Task TestUser()
         {
             var client = CreateClient();

--- a/RelationalAI.Test/UserTest.cs
+++ b/RelationalAI.Test/UserTest.cs
@@ -11,7 +11,8 @@ namespace RelationalAI.Test
         public static string Uuid = Guid.NewGuid().ToString();
         public static string UserEmail = $"csharp-sdk-{Uuid}@example.com";
 
-        [Fact(Skip="User tests are hitting Auth0 API rate limits")]
+        // TODO: Keep it disabled until we fix the Auth0 API rate limiting issue
+        //[Fact] 
         public async Task TestUser()
         {
             var client = CreateClient();

--- a/RelationalAI.Test/UserTest.cs
+++ b/RelationalAI.Test/UserTest.cs
@@ -11,7 +11,7 @@ namespace RelationalAI.Test
         public static string Uuid = Guid.NewGuid().ToString();
         public static string UserEmail = $"csharp-sdk-{Uuid}@example.com";
 
-        [Fact]
+        [Fact (Skip = "User tests are hitting Auth0 API limits")]
         public async Task TestUser()
         {
             var client = CreateClient();

--- a/RelationalAI.Test/UserTest.cs
+++ b/RelationalAI.Test/UserTest.cs
@@ -11,7 +11,7 @@ namespace RelationalAI.Test
         public static string Uuid = Guid.NewGuid().ToString();
         public static string UserEmail = $"csharp-sdk-{Uuid}@example.com";
 
-        [Fact (Skip = "User tests are hitting Auth0 API limits")]
+        [Fact (Skip = "User tests are hitting Auth0 API rate limits")]
         public async Task TestUser()
         {
             var client = CreateClient();


### PR DESCRIPTION
Need to keep the tests disabled until we fix the rate limiting issue. Thought is to introduce caching.