### PR TITLE
Enable logging

### DIFF
--- a/RelationalAI.Test/UnitTest.cs
+++ b/RelationalAI.Test/UnitTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Serilog.Events;
 using Xunit;
 
 namespace RelationalAI.Test
@@ -47,6 +48,9 @@ namespace RelationalAI.Test
             {
                 httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
             }
+
+            // set minimum log level to debug
+            LoggerFactory.LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
             return testClient;
         }
 

--- a/RelationalAI/Client.cs
+++ b/RelationalAI/Client.cs
@@ -24,6 +24,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Polly;
 using Relationalai.Protocol;
+using Serilog.Core;
 
 namespace RelationalAI
 {
@@ -37,11 +38,13 @@ namespace RelationalAI
         private const string PathOAuthClients = "/oauth-clients";
         private readonly Rest _rest;
         private readonly Context _context;
+        private readonly Logger _logger;
 
         public Client(Context context)
         {
             _context = context;
             _rest = new Rest(context);
+            _logger = LoggerFactory.Logger;
         }
 
         public HttpClient HttpClient
@@ -525,6 +528,7 @@ namespace RelationalAI
             if (rsp is string s)
             {
                 var txn = Json<TransactionAsyncCompactResponse>.Deserialize(s);
+                _logger.Debug($"Transaction-ID: {txn.Id}");
                 return new TransactionAsyncResult(txn, new List<ArrowRelation>(), null, new List<object>());
             }
 
@@ -734,6 +738,7 @@ namespace RelationalAI
             }
 
             var transactionResult = Json<TransactionAsyncCompactResponse>.Deserialize(_rest.ReadString(transaction.Data));
+            _logger.Debug($"Transaction-ID: {transactionResult.Id}");
             var metadataProto = _rest.ReadMetadataProtobuf(metadata.Data);
 
             List<object> problemsResult = null;

--- a/RelationalAI/LoggerFactory.cs
+++ b/RelationalAI/LoggerFactory.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Copyright 2022 RelationalAI, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace RelationalAI
+{
+    public sealed class LoggerFactory : IDisposable
+    {
+        static LoggerFactory()
+        {
+            LoggingLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
+            Logger = new LoggerConfiguration()
+                    .WriteTo.Console()
+                    .MinimumLevel.Information()
+                    .MinimumLevel.ControlledBy(LoggingLevelSwitch)
+                    .CreateLogger();
+        }
+
+        public static LoggingLevelSwitch LoggingLevelSwitch { get; set; }
+
+        public static Logger Logger { get; }
+
+        public void Dispose()
+        {
+            Logger?.Dispose();
+        }
+    }
+}

--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -40,6 +40,9 @@
     <PackageReference Include="Microsoft.Data.Analysis" Version="0.19.0" />
     <PackageReference Include="Google.Protobuf" Version="3.19.0" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.19.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
   </ItemGroup>
 
   <Target Name="protogen" BeforeTargets="BeforeBuild">


### PR DESCRIPTION
This PR enables logging in the SDK using `Serilog` ~~framework~~ library and `log.debug` useful response information including `X-Request-ID` header and `transaction id`