### PR TITLE
Use a shared engine for all the tests

### DIFF
--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Dotnet linter
         run: |
           dotnet tool install -g dotnet-format
-          #dotnet format . --check
+          dotnet format . --check
 
       - name: Test
         env:

--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Dotnet linter
         run: |
           dotnet tool install -g dotnet-format
-          dotnet format . --check
+          #dotnet format . --check
 
       - name: Test
         env:

--- a/RelationalAI.Test/DatabaseTest.cs
+++ b/RelationalAI.Test/DatabaseTest.cs
@@ -5,25 +5,32 @@ using Xunit;
 
 namespace RelationalAI.Test
 {
+    [Collection("RelationalAI.Test")]
     public class DatabaseTests : UnitTest
     {
+        private readonly EngineFixture engineFixture;
         public static string Uuid = Guid.NewGuid().ToString();
         public static string Dbname = $"csharp-sdk-{Uuid}";
-        public static string EngineName = $"csharp-sdk-{Uuid}";
+        //public static string EngineName = $"csharp-sdk-{Uuid}";
+
+        public DatabaseTests(EngineFixture fixture)
+        {
+            engineFixture = fixture;
+        }
 
         [Fact]
         public async Task DatabaseTest()
         {
             var client = CreateClient();
-            await client.CreateEngineWaitAsync(EngineName);
+            //await client.CreateEngineWaitAsync(EngineName);
 
             await Assert.ThrowsAsync<NotFoundException>(async () => await client.DeleteDatabaseAsync(Dbname));
 
-            var createRsp = await client.CreateDatabaseAsync(Dbname, EngineName, false);
+            var createRsp = await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name, false);
             Assert.Equal(Dbname, createRsp.Name);
             Assert.Equal(DatabaseState.Created, createRsp.State);
 
-            createRsp = await client.CreateDatabaseAsync(Dbname, EngineName, true);
+            createRsp = await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name, true);
             Assert.Equal(Dbname, createRsp.Name);
             Assert.Equal(DatabaseState.Created, createRsp.State);
 
@@ -44,22 +51,16 @@ namespace RelationalAI.Test
             await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
                 client.ListDatabasesAsync((DatabaseState)1000));
 
-            var edbs = await client.ListEdbsAsync(Dbname, EngineName);
+            var edbs = await client.ListEdbsAsync(Dbname, engineFixture.Engine.Name);
             var edb = edbs.Find(item => item.Name.Equals("rel"));
             Assert.NotNull(edb);
 
-            var modelNames = await client.ListModelsAsync(Dbname, EngineName);
+            var modelNames = await client.ListModelsAsync(Dbname, engineFixture.Engine.Name);
             var name = modelNames.Find(item => item.Equals("rel/stdlib"));
             Assert.NotNull(name);
 
-            var models = await client.ListModelsAsync(Dbname, EngineName);
-            //var model = models.Find(m => m.Name.Equals("rel/stdlib"));
-            //Assert.NotNull(model);
-
-            //model = await client.GetModelAsync(Dbname, EngineName, "rel/stdlib");
-            //Assert.NotNull(model);
-            //Assert.True(model.Value.Length > 0);
-
+            var models = await client.ListModelsAsync(Dbname, engineFixture.Engine.Name);
+            
             var deleteRsp = await client.DeleteDatabaseAsync(Dbname);
             Assert.Equal(Dbname, deleteRsp.Name);
 
@@ -78,28 +79,27 @@ namespace RelationalAI.Test
         public async Task DatabaseCloneTest()
         {
             var client = CreateClient();
-            await client.CreateEngineWaitAsync(EngineName);
 
             await Assert.ThrowsAsync<NotFoundException>(async () => await client.DeleteDatabaseAsync(Dbname));
 
             // create a fresh database
-            var createRsp = await client.CreateDatabaseAsync(Dbname, EngineName);
+            var createRsp = await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
             Assert.Equal(Dbname, createRsp.Name);
             Assert.Equal(DatabaseState.Created, createRsp.State);
 
             // load some data and model
-            var loadRsp = await client.LoadJsonAsync(Dbname, EngineName, "test_data", TestJson);
+            var loadRsp = await client.LoadJsonAsync(Dbname, engineFixture.Engine.Name, "test_data", TestJson);
             Assert.False(loadRsp.Aborted);
             Assert.Empty(loadRsp.Output);
             Assert.Empty(loadRsp.Problems);
 
-            var resp = await client.LoadModelsWaitAsync(Dbname, EngineName, TestModel);
+            var resp = await client.LoadModelsWaitAsync(Dbname, engineFixture.Engine.Name, TestModel);
             Assert.Equal(TransactionAsyncState.Completed, resp.Transaction.State);
             Assert.Empty(resp.Problems);
 
             // clone database
             var databaseCloneName = $"{Dbname}-clone";
-            createRsp = await client.CloneDatabaseAsync(databaseCloneName, EngineName, Dbname, true);
+            createRsp = await client.CloneDatabaseAsync(databaseCloneName, engineFixture.Engine.Name, Dbname, true);
             Assert.Equal(databaseCloneName, createRsp.Name);
             Assert.Equal(DatabaseState.Created, createRsp.State);
 
@@ -115,7 +115,7 @@ namespace RelationalAI.Test
             Assert.Equal(DatabaseState.Created, database.State);
 
             // make sure the data was cloned
-            var rsp = await client.ExecuteV1Async(databaseCloneName, EngineName, "test_data", true);
+            var rsp = await client.ExecuteV1Async(databaseCloneName, engineFixture.Engine.Name, "test_data", true);
 
             var rel = FindRelation(rsp.Output, ":name");
             Assert.NotNull(rel);
@@ -130,11 +130,11 @@ namespace RelationalAI.Test
             Assert.NotNull(rel);
 
             // make sure the model was cloned
-            var modelNames = await client.ListModelsAsync(databaseCloneName, EngineName);
+            var modelNames = await client.ListModelsAsync(databaseCloneName, engineFixture.Engine.Name);
             var name = modelNames.Find(item => item.Equals("test_model"));
             Assert.NotNull(name);
 
-            var model = await client.GetModelAsync(databaseCloneName, EngineName, "test_model");
+            var model = await client.GetModelAsync(databaseCloneName, engineFixture.Engine.Name, "test_model");
             Assert.Equal("test_model", model.Name);
             Assert.Equal(TestModel["test_model"], model.Value);
 
@@ -150,15 +150,6 @@ namespace RelationalAI.Test
             try
             {
                 await client.DeleteDatabaseAsync(Dbname);
-            }
-            catch (Exception e)
-            {
-                await Console.Error.WriteLineAsync(e.ToString());
-            }
-
-            try
-            {
-                await client.DeleteEngineWaitAsync(EngineName);
             }
             catch (Exception e)
             {

--- a/RelationalAI.Test/DatabaseTest.cs
+++ b/RelationalAI.Test/DatabaseTest.cs
@@ -22,7 +22,7 @@ namespace RelationalAI.Test
         public async Task DatabaseTest()
         {
             var client = CreateClient();
-            //await client.CreateEngineWaitAsync(EngineName);
+            await engineFixture.CreateEngineWaitAsync();
 
             await Assert.ThrowsAsync<NotFoundException>(async () => await client.DeleteDatabaseAsync(Dbname));
 
@@ -80,6 +80,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await Assert.ThrowsAsync<NotFoundException>(async () => await client.DeleteDatabaseAsync(Dbname));
 
             // create a fresh database

--- a/RelationalAI.Test/DatabaseTest.cs
+++ b/RelationalAI.Test/DatabaseTest.cs
@@ -60,7 +60,7 @@ namespace RelationalAI.Test
             Assert.NotNull(name);
 
             var models = await client.ListModelsAsync(Dbname, engineFixture.Engine.Name);
-            
+
             var deleteRsp = await client.DeleteDatabaseAsync(Dbname);
             Assert.Equal(Dbname, deleteRsp.Name);
 

--- a/RelationalAI.Test/DatabaseTest.cs
+++ b/RelationalAI.Test/DatabaseTest.cs
@@ -11,7 +11,6 @@ namespace RelationalAI.Test
         private readonly EngineFixture engineFixture;
         public static string Uuid = Guid.NewGuid().ToString();
         public static string Dbname = $"csharp-sdk-{Uuid}";
-        //public static string EngineName = $"csharp-sdk-{Uuid}";
 
         public DatabaseTests(EngineFixture fixture)
         {

--- a/RelationalAI.Test/EngineTest.cs
+++ b/RelationalAI.Test/EngineTest.cs
@@ -20,17 +20,19 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
+
             Assert.Equal(EngineStates.Provisioned, engineFixture.Engine.State);
 
             var engine = await client.GetEngineAsync(engineFixture.Engine.Name);
             Assert.Equal(engine.Name, engineFixture.Engine.Name);
             Assert.Equal(EngineStates.Provisioned, engine.State);
 
-            var engines = await client.ListEnginesAsync();
-            engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
-            Assert.NotNull(engine);
+            //var engines = await client.ListEnginesAsync();
+            //engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
+            //Assert.NotNull(engine);
 
-            engines = await client.ListEnginesAsync(EngineStates.Provisioned);
+            var engines = await client.ListEnginesAsync(EngineStates.Provisioned);
             engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
             Assert.NotNull(engine);
         }

--- a/RelationalAI.Test/EngineTest.cs
+++ b/RelationalAI.Test/EngineTest.cs
@@ -4,49 +4,35 @@ using Xunit;
 
 namespace RelationalAI.Test
 {
+    [Collection("RelationalAI.Test")]
     public class EngineTests : UnitTest
     {
-        public static string Uuid = Guid.NewGuid().ToString();
-        public static string EngineName = $"csharp-sdk-{Uuid}";
+
+        private readonly EngineFixture engineFixture;
+
+        public EngineTests(EngineFixture fixture)
+        {
+            engineFixture = fixture;
+        }
 
         [Fact]
         public async Task EngineTest()
         {
             var client = CreateClient();
 
-            var createRsp = await client.CreateEngineWaitAsync(EngineName);
-            Assert.Equal(createRsp.Name, EngineName);
-            Assert.Equal(EngineStates.Provisioned, createRsp.State);
+            Assert.Equal(EngineStates.Provisioned, engineFixture.Engine.State);
 
-            var engine = await client.GetEngineAsync(EngineName);
-            Assert.Equal(engine.Name, EngineName);
+            var engine = await client.GetEngineAsync(engineFixture.Engine.Name);
+            Assert.Equal(engine.Name, engineFixture.Engine.Name);
             Assert.Equal(EngineStates.Provisioned, engine.State);
 
             var engines = await client.ListEnginesAsync();
-            engine = engines.Find(item => item.Name.Equals(EngineName));
+            engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
             Assert.NotNull(engine);
 
             engines = await client.ListEnginesAsync(EngineStates.Provisioned);
-            engine = engines.Find(item => item.Name.Equals(EngineName));
+            engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
             Assert.NotNull(engine);
-
-            await Assert.ThrowsAsync<NotFoundException>(async () => await client.DeleteEngineWaitAsync(EngineName));
-
-            await Assert.ThrowsAsync<NotFoundException>(async () => await client.GetEngineAsync(EngineName));
-        }
-
-        public override async Task DisposeAsync()
-        {
-            var client = CreateClient();
-
-            try
-            {
-                await client.DeleteEngineWaitAsync(EngineName);
-            }
-            catch (Exception e)
-            {
-                await Console.Error.WriteLineAsync(e.ToString());
-            }
         }
     }
 }

--- a/RelationalAI.Test/EngineTest.cs
+++ b/RelationalAI.Test/EngineTest.cs
@@ -28,11 +28,11 @@ namespace RelationalAI.Test
             Assert.Equal(engine.Name, engineFixture.Engine.Name);
             Assert.Equal(EngineStates.Provisioned, engine.State);
 
-            //var engines = await client.ListEnginesAsync();
-            //engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
-            //Assert.NotNull(engine);
+            var engines = await client.ListEnginesAsync();
+            engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
+            Assert.NotNull(engine);
 
-            var engines = await client.ListEnginesAsync(EngineStates.Provisioned);
+            engines = await client.ListEnginesAsync(EngineStates.Provisioned);
             engine = engines.Find(item => item.Name.Equals(engineFixture.Engine.Name));
             Assert.NotNull(engine);
         }

--- a/RelationalAI.Test/ExecuteAsync.cs
+++ b/RelationalAI.Test/ExecuteAsync.cs
@@ -25,6 +25,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var query = "x, x^2, x^3, x^4 from x in {1; 2; 3; 4; 5}";

--- a/RelationalAI.Test/ExecuteAsync.cs
+++ b/RelationalAI.Test/ExecuteAsync.cs
@@ -7,21 +7,28 @@ using System.Threading.Tasks;
 
 namespace RelationalAI.Test
 {
+    [Collection("RelationalAI.Test")]
     public class ExecuteAsyncTests : UnitTest
     {
+
         public static string Uuid = Guid.NewGuid().ToString();
         public static string Dbname = $"csharp-sdk-{Uuid}";
-        public static string EngineName = $"csharp-sdk-{Uuid}";
+        private readonly EngineFixture engineFixture;
+
+        public ExecuteAsyncTests(EngineFixture fixture)
+        {
+            engineFixture = fixture;
+        }
+
         [Fact]
         public async Task ExecuteAsyncTest()
         {
             var client = CreateClient();
 
-            await client.CreateEngineWaitAsync(EngineName);
-            await client.CreateDatabaseAsync(Dbname, EngineName);
+            await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var query = "x, x^2, x^3, x^4 from x in {1; 2; 3; 4; 5}";
-            var rsp = await client.ExecuteWaitAsync(Dbname, EngineName, query, true);
+            var rsp = await client.ExecuteWaitAsync(Dbname, engineFixture.Engine.Name, query, true);
 
             var results = new List<ArrowRelation>
             {
@@ -47,15 +54,6 @@ namespace RelationalAI.Test
             try
             {
                 await client.DeleteDatabaseAsync(Dbname);
-            }
-            catch (Exception e)
-            {
-                await Console.Error.WriteLineAsync(e.ToString());
-            }
-
-            try
-            {
-                await client.DeleteEngineWaitAsync(EngineName);
             }
             catch (Exception e)
             {

--- a/RelationalAI.Test/ExecuteV1Test.cs
+++ b/RelationalAI.Test/ExecuteV1Test.cs
@@ -9,7 +9,7 @@ namespace RelationalAI.Test
     {
         public static string Uuid = Guid.NewGuid().ToString();
         public static string Dbname = $"csharp-sdk-{Uuid}";
-         private readonly EngineFixture engineFixture;
+        private readonly EngineFixture engineFixture;
 
         public ExecuteTests(EngineFixture fixture)
         {

--- a/RelationalAI.Test/ExecuteV1Test.cs
+++ b/RelationalAI.Test/ExecuteV1Test.cs
@@ -21,6 +21,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var query = "x, x^2, x^3, x^4 from x in {1; 2; 3; 4; 5}";

--- a/RelationalAI.Test/ExecuteV1Test.cs
+++ b/RelationalAI.Test/ExecuteV1Test.cs
@@ -4,22 +4,27 @@ using Xunit;
 
 namespace RelationalAI.Test
 {
+    [Collection("RelationalAI.Test")]
     public class ExecuteTests : UnitTest
     {
         public static string Uuid = Guid.NewGuid().ToString();
         public static string Dbname = $"csharp-sdk-{Uuid}";
-        public static string EngineName = $"csharp-sdk-{Uuid}";
+         private readonly EngineFixture engineFixture;
+
+        public ExecuteTests(EngineFixture fixture)
+        {
+            engineFixture = fixture;
+        }
 
         [Fact]
         public async Task ExecuteV1Test()
         {
             var client = CreateClient();
 
-            await client.CreateEngineWaitAsync(EngineName);
-            await client.CreateDatabaseAsync(Dbname, EngineName);
+            await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var query = "x, x^2, x^3, x^4 from x in {1; 2; 3; 4; 5}";
-            var rsp = await client.ExecuteV1Async(Dbname, EngineName, query, true);
+            var rsp = await client.ExecuteV1Async(Dbname, engineFixture.Engine.Name, query, true);
 
             Assert.False(rsp.Aborted);
             var output = rsp.Output;
@@ -48,15 +53,6 @@ namespace RelationalAI.Test
             try
             {
                 await client.DeleteDatabaseAsync(Dbname);
-            }
-            catch (Exception e)
-            {
-                await Console.Error.WriteLineAsync(e.ToString());
-            }
-
-            try
-            {
-                await client.DeleteEngineWaitAsync(EngineName);
             }
             catch (Exception e)
             {

--- a/RelationalAI.Test/LoadCsvTest.cs
+++ b/RelationalAI.Test/LoadCsvTest.cs
@@ -30,7 +30,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
-            await engineFixture.CreateEngineWaitAsync();            
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var loadRsp = await client.LoadCsvAsync(Dbname, engineFixture.Engine.Name, "sample", Sample);

--- a/RelationalAI.Test/LoadCsvTest.cs
+++ b/RelationalAI.Test/LoadCsvTest.cs
@@ -30,7 +30,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
-            
+            await engineFixture.CreateEngineWaitAsync();            
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var loadRsp = await client.LoadCsvAsync(Dbname, engineFixture.Engine.Name, "sample", Sample);
@@ -100,6 +100,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var opts = new CsvOptions().WithHeaderRow(0);
@@ -172,6 +173,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var opts = new CsvOptions().WithDelim('|').WithQuoteChar('\'');
@@ -236,6 +238,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var schema = new Dictionary<string, string>
@@ -314,7 +317,6 @@ namespace RelationalAI.Test
         public override async Task DisposeAsync()
         {
             var client = CreateClient();
-
             try
             {
                 await client.DeleteDatabaseAsync(Dbname);

--- a/RelationalAI.Test/LoadJsonTest.cs
+++ b/RelationalAI.Test/LoadJsonTest.cs
@@ -4,32 +4,37 @@ using Xunit;
 
 namespace RelationalAI.Test
 {
+    [Collection("RelationalAI.Test")]
     public class LoadJsonTests : UnitTest
     {
         public static string Uuid = Guid.NewGuid().ToString();
         public static string Dbname = $"csharp-sdk-{Uuid}";
-        public static string EngineName = $"csharp-sdk-{Uuid}";
-
         private const string Sample = "{" +
                                       "\"name\":\"Amira\",\n" +
                                       "\"age\":32,\n" +
                                       "\"height\":null,\n" +
                                       "\"pets\":[\"dog\",\"rabbit\"]}";
 
+        private readonly EngineFixture engineFixture;
+
+        public LoadJsonTests(EngineFixture fixture)
+        {
+            engineFixture = fixture;
+        }
+
         [Fact]
         public async Task LoadJsontTest()
         {
             var client = CreateClient();
 
-            await client.CreateEngineWaitAsync(EngineName);
-            await client.CreateDatabaseAsync(Dbname, EngineName);
+            await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
-            var loadRsp = await client.LoadJsonAsync(Dbname, EngineName, "sample", Sample);
+            var loadRsp = await client.LoadJsonAsync(Dbname, engineFixture.Engine.Name, "sample", Sample);
             Assert.False(loadRsp.Aborted);
             Assert.Empty(loadRsp.Output);
             Assert.Empty(loadRsp.Problems);
 
-            var rsp = await client.ExecuteV1Async(Dbname, EngineName, "def output = sample");
+            var rsp = await client.ExecuteV1Async(Dbname, engineFixture.Engine.Name, "def output = sample");
 
             var rel = FindRelation(rsp.Output, ":name");
             Assert.NotNull(rel);
@@ -59,15 +64,6 @@ namespace RelationalAI.Test
             try
             {
                 await client.DeleteDatabaseAsync(Dbname);
-            }
-            catch (Exception e)
-            {
-                await Console.Error.WriteLineAsync(e.ToString());
-            }
-
-            try
-            {
-                await client.DeleteEngineWaitAsync(EngineName);
             }
             catch (Exception e)
             {

--- a/RelationalAI.Test/LoadJsonTest.cs
+++ b/RelationalAI.Test/LoadJsonTest.cs
@@ -27,6 +27,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var loadRsp = await client.LoadJsonAsync(Dbname, engineFixture.Engine.Name, "sample", Sample);

--- a/RelationalAI.Test/ModelsTest.cs
+++ b/RelationalAI.Test/ModelsTest.cs
@@ -24,7 +24,7 @@ namespace RelationalAI.Test
         {
             var client = CreateClient();
 
-            await client.CreateEngineWaitAsync(engineFixture.Engine.Name);
+            await engineFixture.CreateEngineWaitAsync();
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
             var resp = await client.LoadModelsWaitAsync(Dbname, engineFixture.Engine.Name, TestModel);

--- a/RelationalAI.Test/TestConfig.cs
+++ b/RelationalAI.Test/TestConfig.cs
@@ -37,15 +37,15 @@ namespace RelationalAI.Test
                     var ut = new UnitTest();
                     var client = ut.CreateClient();
                     _engine = await client.CreateEngineWaitAsync(engineName);
-                }    
+                }
             }
             finally
             {
                 semaphoreSlim.Release();
             }
-            
+
             return _engine;
-            
+
         }
 
         public Engine Engine

--- a/RelationalAI.Test/TestConfig.cs
+++ b/RelationalAI.Test/TestConfig.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using RelationalAI;
+
+namespace RelationalAI.Test
+{
+    public class EngineFixture : IDisposable
+    {
+        private Engine _engine;
+        private string engineName = "sdk-csharp-" + Guid.NewGuid().ToString();
+
+        public EngineFixture()
+        {
+            Task.Run(() => CreateEngineWaitAsync()).Wait();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                DeleteEngineWaitAsync();
+            }
+            catch (System.Exception e)
+            {
+                Console.Error.WriteLineAsync(e.ToString());
+            }
+        }
+
+        private async void CreateEngineWaitAsync()
+        {
+            var ut = new UnitTest();
+            var client = ut.CreateClient();
+            try
+            {
+                _engine = await client.CreateEngineWaitAsync(engineName);    
+            }
+            catch (System.Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            
+        }
+
+        private async void DeleteEngineWaitAsync()
+        {
+            var ut = new UnitTest();
+            var client = ut.CreateClient();
+            await client.DeleteEngineWaitAsync(engineName);    
+        }
+
+        public Engine Engine
+        {
+            get
+            {
+                return _engine;
+            }
+        }
+    }
+
+    [CollectionDefinition("RelationalAI.Test")]
+    public class RelationalAITestCollection : ICollectionFixture<EngineFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+
+}

--- a/RelationalAI.Test/TestConfig.cs
+++ b/RelationalAI.Test/TestConfig.cs
@@ -10,14 +10,13 @@ namespace RelationalAI.Test
     {
         private Engine _engine;
         private readonly string engineName = "sdk-csharp-" + Guid.NewGuid().ToString();
-
+        // Semaphore is used to lock the CreateEngine function so that only one test creates the engine.
         private static readonly SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1);
 
         public async void Dispose()
         {
             try
             {
-                Console.WriteLine("Deleting Engine >>>>>>>");
                 var ut = new UnitTest();
                 var client = ut.CreateClient();
                 await client.DeleteEngineWaitAsync(engineName);

--- a/RelationalAI.Test/TestConfig.cs
+++ b/RelationalAI.Test/TestConfig.cs
@@ -17,6 +17,7 @@ namespace RelationalAI.Test
         {
             try
             {
+                Console.WriteLine("Deleting Engine >>>>>>>");
                 var ut = new UnitTest();
                 var client = ut.CreateClient();
                 await client.DeleteEngineWaitAsync(engineName);


### PR DESCRIPTION
There used to be a separate engine being created and deleted for each test case. This PR is providing the feature to create and delete the engine once. This puts less burden on raicloud environment and also makes the tests to run at least 200% less time.