### PR TITLE
Fix retry policy for HttpError's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-
+# v0.9.11-alpha
+* Fix common retry policy to not retry on `HttpError` with 4xx Status Codes, but only on 5xx.
 # v0.9.10-alpha
 * Bump up google protobuf version.
 # v0.9.9-alpha

--- a/RelationalAI/CommonPolicies.cs
+++ b/RelationalAI/CommonPolicies.cs
@@ -99,7 +99,7 @@ namespace RelationalAI
                 .Handle<HttpRequestException>()
 
                 // Server error response received (5xx status code, etc.)
-                .Or<HttpError>()
+                .Or<HttpError>(e => e.StatusCode >= 500)
 
                 // Retry 5 times with overheadRate param of the time the transaction has been running so far
                 // And rethrow the exception.

--- a/RelationalAI/RelationalAI.csproj
+++ b/RelationalAI/RelationalAI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.9.10-alpha</Version>
+    <Version>0.9.11-alpha</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>RAI</PackageId>
     <Authors>RelationalAI</Authors>


### PR DESCRIPTION
[One of the recently merged PR](https://github.com/RelationalAI/rai-sdk-csharp/pull/53/files#diff-b1073a4a1ef9efb9b130e927030cc91f0520e89313eccc8d7693fa3e0a0e090c)s: 
changed the retry Policy for 4xx status codes. Previously `ApiException` was only thrown on 5xx status codes, therefore 4xx status codes were immediately propagated back to user - which is expected behavior. But now that `HttpError` is thrown on 4xx status codes as well, the policy is retrying 5 times before actually throwing exceptions (i.e. with 404 errors) back to user.

This PR returns the previous behavior back.