### PR TITLE
Fix raicode default access token handler test failure

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -51,5 +51,7 @@ runs:
         CLIENT_CREDENTIALS_URL: ${{ inputs.client_credentials_url }}
         HOST: ${{ inputs.rai_host }}
         CUSTOM_HEADERS: ${{ inputs.custom_headers }}
-      run: dotnet test --logger "console;verbosity=detailed"
+      run: |
+        mkdir ~/.rai
+        dotnet test --logger "console;verbosity=detailed"
       shell: bash

--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Dotnet linter
         run: |
-          mkdir ~/.rai
           dotnet tool install -g dotnet-format
           dotnet format . --check
 


### PR DESCRIPTION
The test action should create `~/.rai` dir before running the default access token handler tests also to make sure we are caching tokens locally on disk

