### PR TITLE
Adding '@function' to some definitions to force correct key/values

### DIFF
--- a/RelationalAI.Test/ExecuteV1Test.cs
+++ b/RelationalAI.Test/ExecuteV1Test.cs
@@ -28,7 +28,7 @@ namespace RelationalAI.Test
             engineFixture.Engine.State.Should().Be(EngineStates.Provisioned);
             await client.CreateDatabaseAsync(Dbname, engineFixture.Engine.Name);
 
-            var query = "def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4";
+            var query = "@function def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4";
             var rsp = await client.ExecuteV1Async(Dbname, engineFixture.Engine.Name, query, true);
 
             rsp.Aborted.Should().BeFalse();


### PR DESCRIPTION
RAICode PR https://github.com/RelationalAI/raicode/pull/23464 made FD inference more precise changing the output relkey